### PR TITLE
Make CTArray2D a subclass of Collection

### DIFF
--- a/src/Containers-Array2D/CTArray2D.class.st
+++ b/src/Containers-Array2D/CTArray2D.class.st
@@ -5,7 +5,7 @@ Check the numerous tests.
 "
 Class {
 	#name : #CTArray2D,
-	#superclass : #Object,
+	#superclass : #Collection,
 	#instVars : [
 		'width',
 		'contents'
@@ -63,6 +63,12 @@ CTArray2D class >> width: width height: height [
 { #category : #'instance creation' }
 CTArray2D class >> width: width height: height type: collectionClass [
 	^ self basicNew width: width height: height type: collectionClass
+]
+
+{ #category : #adding }
+CTArray2D >> add: newObject [
+
+	self shouldNotImplement
 ]
 
 { #category : #converting }
@@ -237,6 +243,12 @@ CTArray2D >> printOn: aStream [
 					separatedBy: [ aStream space ].
 					aStream cr ].
 	aStream nextPutAll: ')'.
+]
+
+{ #category : #removing }
+CTArray2D >> remove: oldObject ifAbsent: anExceptionBlock [ 
+
+	self shouldNotImplement
 ]
 
 { #category : #enumeration }


### PR DESCRIPTION
Collection provide a lot of things and introduces some of the selectors that are redefined in CTArray2D.

The abstraction of this specialization is that a CTArray2D instance is a collection of values indexed by 2D coordinates (points), with constraints on the coordinates (like with most indexed/keyed collections, there are some constraints...).

Since CTArray2D is not growable, I forbid some related methods (like it is done with ArrayedCollection) even if I'm not a fan of restricting methods :(

Obviously, many inherited things might break, especially methods that rely on `species` since a simple `self species new: aSize` breaks (as `new:` is disabled in CTArray2D).
For these, two possible avenues are to redefine most methods that rely on species, or to redefine species as a simpler less restrictive collection (like it is done with `Interval` for instance).

Anyway, this first PR is needed to be able to fix things later, and "Less talking more doing" says the README.