### PR TITLE
Fixes #29

### DIFF
--- a/src/Containers-Array2D/CTAlternateArray2D.class.st
+++ b/src/Containers-Array2D/CTAlternateArray2D.class.st
@@ -33,16 +33,23 @@ CTAlternateArray2D class >> width2Height3 [
 { #category : 'iterate' }
 CTAlternateArray2D >> allPositionsDo: aBlock [
 	"Execute a Block on all the positions (points) of the receiver."
-	self firstPosition pointTo: self dimension do: aBlock
+	1 to: self height do: [ :y |
+        1 to: self width do: [ :x |aBlock value: (x @ y)]]
 ]
 
 { #category : 'iterate' }
 CTAlternateArray2D >> allPositionsWithin: someDistance from: someOrigin [
-	| answer topLeft bottomRight |
+	| answer xRange yRange |
 	answer := OrderedCollection new.
-	topLeft := someOrigin - someDistance max: self firstPosition.
-	bottomRight := someOrigin + someDistance min: self dimension.
-	topLeft pointTo: bottomRight do: [ :each | answer add: each ].
+	xRange := (someOrigin x - someDistance x max: 1) to:
+		(someOrigin x + someDistance x min: self width).
+
+	yRange := (someOrigin y - someDistance y max: 1) to:
+		(someOrigin y + someDistance y min: self height).
+
+	yRange do: [ :y |
+		answer addAll: (xRange collect: [ :x | x @ y ]) ].
+
 	^ answer
 ]
 


### PR DESCRIPTION

This pull request includes changes to the `CTAlternateArray2D` class to improve the iteration methods by making them more efficient and readable. 
* [`CTAlternateArray2D >> allPositionsDo:`](diffhunk://#diff-37e9217671d1efeb166c4cca23efa10d772d635df6174af2c195dfb92b82f57cL36-R52): Replaced the call to `firstPosition pointTo: self dimension do:` with nested loops iterating over the height and width, directly applying the block to each position.
* [`CTAlternateArray2D >> allPositionsWithin:from:`](diffhunk://#diff-37e9217671d1efeb166c4cca23efa10d772d635df6174af2c195dfb92b82f57cL36-R52): Simplified the method by using ranges for x and y coordinates and collecting points within these ranges, instead of calculating top-left and bottom-right points and iterating over them.