### PR TITLE
Feat: Add full column iteration and directional navigation paths to CTArray2D

### DIFF
--- a/src/Containers-Array2D-Tests/CTArray2DTest.class.st
+++ b/src/Containers-Array2D-Tests/CTArray2DTest.class.st
@@ -136,6 +136,25 @@ CTArray2DTest >> testCannotAccessWithWrongCoordinates [
 	self should: [ self arrayClass width2Height3 atColumn: 6 atRow: 1 ] raise: SubscriptOutOfBounds
 ]
 
+{ #category : 'tests' }
+CTArray2DTest >> testColumns [
+	| foo |
+	foo := self arrayClass width2Height3.
+	self assert: foo columns equals: #(#(1 3 5) #(2 4 6))
+]
+
+{ #category : 'tests' }
+CTArray2DTest >> testColumnsDo [
+	| foo array columnIndex |
+	foo := self arrayClass width2Height3.
+	array := Array new: 2.
+	columnIndex := 1.
+	foo columnsDo: [ :column | 
+		array at: columnIndex put: column.
+		columnIndex := columnIndex + 1 ].
+	self assert: array equals: #(#(1 3 5) #(2 4 6))
+]
+
 { #category : 'tests-copying' }
 CTArray2DTest >> testCopy [
 	| foo cop |
@@ -211,6 +230,78 @@ CTArray2DTest >> testFromArray [
 	
 ]
 
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromBottomToTopFromLeftToRightDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromBottomToTopFromLeftToRightDo: [ :each | res add: each ].
+	self assert: res equals: #(5 3 1 6 4 2) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromBottomToTopFromRightToLeftDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromBottomToTopFromRightToLeftDo: [ :each | res add: each ].
+	self assert: res equals: #(6 4 2 5 3 1) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromLeftToRightFromBottomToTopDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromLeftToRightFromBottomToTopDo: [ :each | res add: each ].
+	self assert: res equals: #(5 6 3 4 1 2) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromLeftToRightFromTopToBottomDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromLeftToRightFromTopToBottomDo: [ :each | res add: each ].
+	self assert: res equals: #(1 2 3 4 5 6) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromRightToLeftFromBottomToTopDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromRightToLeftFromBottomToTopDo: [ :each | res add: each ].
+	self assert: res equals: #(6 5 4 3 2 1) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromRightToLeftFromTopToBottomDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromRightToLeftFromTopToBottomDo: [ :each | res add: each ].
+	self assert: res equals: #(2 1 4 3 6 5) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromTopToBottomFromLeftToRightDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromTopToBottomFromLeftToRightDo: [ :each | res add: each ].
+	self assert: res equals: #(1 3 5 2 4 6) asOrderedCollection
+]
+
+{ #category : 'tests-enumeration' }
+CTArray2DTest >> testFromTopToBottomFromRightToLeftDo [
+	|foo res|
+	foo := self arrayClass width2Height3.
+	res := OrderedCollection new.
+	foo fromTopToBottomFromRightToLeftDo: [ :each | res add: each ].
+	self assert: res equals: #(2 4 6 1 3 5) asOrderedCollection
+]
+
 { #category : 'tests-accessing' }
 CTArray2DTest >> testHeight [
 
@@ -223,17 +314,6 @@ CTArray2DTest >> testIndexXY [
 	foo := self arrayClass width: 5 height: 20.
 
 	self assert: (foo indexX: 2 y: 3) equals: (3-1)*(foo width)+2 
-]
-
-{ #category : 'tests' }
-CTArray2DTest >> testLeftToRightFromBottomToTopDo [
-
-	| a2d res |
-	a2d := CTArray2D fromArray: #(1 2 3 4 5 6) width: 3.
-	res := OrderedCollection new. 
-	a2d leftToRightFromBottomToTopDo: [ :each | res add: each ].
-	self assert: res equals: #(4 5 6 1 2 3 ) asOrderedCollection
-	 
 ]
 
 { #category : 'tests-printing' }

--- a/src/Containers-Array2D/CTAlternateArray2D.class.st
+++ b/src/Containers-Array2D/CTAlternateArray2D.class.st
@@ -32,17 +32,22 @@ CTAlternateArray2D class >> width2Height3 [
 
 { #category : 'iterate' }
 CTAlternateArray2D >> allPositionsDo: aBlock [
-	"Execute a Block on all the positions (points) of the receiver."
-	self firstPosition pointTo: self dimension do: aBlock
+	1 to: self width do: [ :x |
+		1 to: self height do: [ :y |
+			aBlock value: x@y ] ]
 ]
 
 { #category : 'iterate' }
-CTAlternateArray2D >> allPositionsWithin: someDistance from: someOrigin [
+CTAlternateArray2D >> allPositionsWithin: someDistance from: someOrigin [ 
 	| answer topLeft bottomRight |
 	answer := OrderedCollection new.
 	topLeft := someOrigin - someDistance max: self firstPosition.
 	bottomRight := someOrigin + someDistance min: self dimension.
-	topLeft pointTo: bottomRight do: [ :each | answer add: each ].
+	
+	topLeft x to: bottomRight x do: [ :x |
+		topLeft y to: bottomRight y do: [ :y |
+			answer add: x@y ] ].
+			
 	^ answer
 ]
 

--- a/src/Containers-Array2D/CTArray2D.class.st
+++ b/src/Containers-Array2D/CTArray2D.class.st
@@ -225,6 +225,16 @@ CTArray2D >> atX: x atY: y put: value [
 	^ contents at: (self indexX: x y: y) put: value
 ]
 
+{ #category : 'converting' }
+CTArray2D >> columns [
+	^ (1 to: self width) collect: [ :columnIndex | self atColumn: columnIndex ]
+]
+
+{ #category : 'enumeration' }
+CTArray2D >> columnsDo: aBlock [
+	1 to: self width do: [ :i | aBlock value: (self atColumn: i) ]
+]
+
 { #category : 'private' }
 CTArray2D >> contents [
 
@@ -253,6 +263,62 @@ CTArray2D >> extent: extent fromArray: anArray [
 		ifFalse: [ ^ self error: 'dimensions don''t match' ].
 	width := extent x.
 	contents := anArray
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromBottomToTopFromLeftToRightDo: aBlock [
+	1 to: self width do: [:col |
+		self height to: 1 by: -1 do: [:row |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromBottomToTopFromRightToLeftDo: aBlock [
+	self width to: 1 by: -1 do: [:col |
+		self height to: 1 by: -1 do: [:row |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromLeftToRightFromBottomToTopDo: aBlock [
+	self height to: 1 by: -1 do: [:row |
+		1 to: self width do: [:col |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromLeftToRightFromTopToBottomDo: aBlock [
+	1 to: self height do: [ :row |
+		1 to: self width do: [ :col |
+			aBlock value: (self atColumn: col atRow: row) ] ]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromRightToLeftFromBottomToTopDo: aBlock [
+	self height to: 1 by: -1 do: [:row |
+		self width to: 1 by: -1 do: [:col |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromRightToLeftFromTopToBottomDo: aBlock [
+	1 to: self height do: [:row |
+		self width to: 1 by: -1 do: [:col |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromTopToBottomFromLeftToRightDo: aBlock [
+	1 to: self width do: [:col |
+		1 to: self height do: [:row |
+			aBlock value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> fromTopToBottomFromRightToLeftDo: aBlock [
+	self width to: 1 by: -1 do: [:col |
+		1 to: self height do: [:row |
+			aBlock value: (self atColumn: col atRow: row)]]
 ]
 
 { #category : 'comparing' }
@@ -285,20 +351,6 @@ CTArray2D >> indexX: x y: y [
 CTArray2D >> isSelfEvaluating [
 
 	^ self class == CTArray2D and: [ contents isSelfEvaluating ]
-]
-
-{ #category : 'enumerating' }
-CTArray2D >> leftToRightFromBottomToTopDo: aBlock [
-	"Apply a block to each element following that order left to right but from bottom to top"
-	"123
-	456
-	=> 
-	456123
-	"
-	
-	 self height to: 1 by: -1 do: [:row |
-		1 to: self width do: [:col |
-			aBlock  value: (self atColumn: col atRow: row)]]
 ]
 
 { #category : 'accessing - compatibility' }


### PR DESCRIPTION
This PR brings the iteration and enumeration API of `CTArray2D` up to parity with `CTNewArray2D`.

- Added `columns` and `columnsDo:` to allow block manipulation of full columns.
- Implemented the 8 directional navigation paths (e.g., `fromBottomToTopFromLeftToRightDo:`, etc.) in `CTArray2D`.
- Added complete Unit test in `CTArray2DTest` for all new iteration methods.

- **Fixes #11**
- **Fixes #22**