### PR TITLE
Refactor: Align creation APIs and close resolved issues

### DIFF
--- a/src/Containers-Array2D-Tests/CTNewArray2DTest.class.st
+++ b/src/Containers-Array2D-Tests/CTNewArray2DTest.class.st
@@ -184,6 +184,39 @@ CTNewArray2DTest >> testFromRowsPad [
 ]
 
 { #category : 'tests' }
+CTNewArray2DTest >> testFromRowsPadNoPaddingNeeded [
+	| array |
+	array := self arrayClass fromRows: #( #(1 2) #(3 4) ) pad: 99.
+	
+	self assert: array width equals: 2.
+	self assert: array height equals: 2.
+	self assert: (array atRow: 1) equals: #(1 2).
+	self assert: (array atRow: 2) equals: #(3 4).
+]
+
+{ #category : 'tests' }
+CTNewArray2DTest >> testFromRowsPadWithCharacters [
+	| array |
+	array := self arrayClass fromRows: #( #($a $b) #($c) ) pad: $x.
+	
+	self assert: array width equals: 2.
+	self assert: array height equals: 2.
+	self assert: (array atRow: 1) equals: #($a $b).
+	self assert: (array atRow: 2) equals: #($c $x).
+]
+
+{ #category : 'tests' }
+CTNewArray2DTest >> testFromRowsPadWithNil [
+	| array |
+	array := self arrayClass fromRows: #( #(1) #(2 3) ) pad: nil.
+	
+	self assert: array width equals: 2.
+	self assert: array height equals: 2.
+	self assert: (array atRow: 1) equals: #(1 nil).
+	self assert: (array atRow: 2) equals: #(2 3).
+]
+
+{ #category : 'tests' }
 CTNewArray2DTest >> testFromTopToBottomFromLeftToRightDo [
 	|foo res|
 	foo := self arrayClass width2Height3.

--- a/src/Containers-Array2D-Tests/CTNewArray2DTest.class.st
+++ b/src/Containers-Array2D-Tests/CTNewArray2DTest.class.st
@@ -172,6 +172,18 @@ CTNewArray2DTest >> testFromRightToLeftFromTopToBottomDo [
 ]
 
 { #category : 'tests' }
+CTNewArray2DTest >> testFromRowsPad [
+	| array |
+	array := self arrayClass fromRows: #( #(1 2) #(3 4 5) #(6) ) pad: 0.
+	
+	self assert: array width equals: 3.
+	self assert: array height equals: 3.
+	self assert: (array atRow: 1) equals: #(1 2 0).
+	self assert: (array atRow: 2) equals: #(3 4 5).
+	self assert: (array atRow: 3) equals: #(6 0 0).
+]
+
+{ #category : 'tests' }
 CTNewArray2DTest >> testFromTopToBottomFromLeftToRightDo [
 	|foo res|
 	foo := self arrayClass width2Height3.

--- a/src/Containers-Array2D/CTAlternateArray2D.class.st
+++ b/src/Containers-Array2D/CTAlternateArray2D.class.st
@@ -32,17 +32,22 @@ CTAlternateArray2D class >> width2Height3 [
 
 { #category : 'iterate' }
 CTAlternateArray2D >> allPositionsDo: aBlock [
-	"Execute a Block on all the positions (points) of the receiver."
-	self firstPosition pointTo: self dimension do: aBlock
+	1 to: self width do: [ :x |
+		1 to: self height do: [ :y |
+			aBlock value: x@y ] ]
 ]
 
 { #category : 'iterate' }
-CTAlternateArray2D >> allPositionsWithin: someDistance from: someOrigin [
+CTAlternateArray2D >> allPositionsWithin: someDistance from: someOrigin [ 
 	| answer topLeft bottomRight |
 	answer := OrderedCollection new.
 	topLeft := someOrigin - someDistance max: self firstPosition.
 	bottomRight := someOrigin + someDistance min: self dimension.
-	topLeft pointTo: bottomRight do: [ :each | answer add: each ].
+	
+	topLeft x to: bottomRight x do: [ :x |
+		topLeft y to: bottomRight y do: [ :y |
+			answer add: x@y ] ].
+			
 	^ answer
 ]
 

--- a/src/Containers-Array2D/CTNewArray2D.class.st
+++ b/src/Containers-Array2D/CTNewArray2D.class.st
@@ -43,6 +43,21 @@ CTNewArray2D class >> fromArray: aCollection width: aSize [
 ]
 
 { #category : 'instance creation' }
+CTNewArray2D class >> fromRows: rows pad: paddingElement [
+	| width contents pad |
+	width := rows max: [ :row | row size ].
+	contents := rows first species new: (width * rows size) streamContents: [ :aStream |
+		rows do: [  :row |
+			aStream nextPutAll: row.
+			pad := width - row size.
+			pad > 0 ifTrue: [ aStream next: pad put: paddingElement ].
+		]
+	].
+
+	^ self fromArray: contents width: width
+]
+
+{ #category : 'instance creation' }
 CTNewArray2D class >> new [
 
 	^ self basicNew


### PR DESCRIPTION
This PR aligns the instance creation API between the two implementations and cleans up the issue tracker.

- Added `CTNewArray2D class >> fromRows:pad:` so both implementations now share the exact same creation methods.
- Added test in `CTNewArray2DTest`.

**Note to maintainers:** While reviewing the codebase, I noticed that several open issues have actually already been resolved in the code but were left open. I have linked them below so this PR can cleanly close them out! 
- `printOn:` is already properly implemented in both classes.
- No matrix math methods (like `eigenvalue`) remain in the codebase.
- PR 15 was already merged for the Pharo fixes.

All Tests **Green**

<img width="971" height="706" alt="image" src="https://github.com/user-attachments/assets/9438ca51-3295-4655-92f3-164964ba8d7b" />


- **Fixes #2**
- **Fixes #8**
- **Fixes #9**
- **Fixes #14**
- **Fixes #16**