### PR TITLE
Feat: Add wrap and neighbor access methods for grid logic

### DIFF
--- a/src/Containers-Array2D-Tests/CTArray2DTest.class.st
+++ b/src/Containers-Array2D-Tests/CTArray2DTest.class.st
@@ -88,6 +88,34 @@ CTArray2DTest >> testAtColumnPut [
 ]
 
 { #category : 'tests-accessing' }
+CTArray2DTest >> testAtColumnWrapAtRowWrap [
+
+	| array |
+	array := self arrayClass width2Height3.
+	
+	self assert: (array atColumnWrap: 1 atRowWrap: 1) equals: 1.
+	
+	self assert: (array atColumnWrap: 3 atRowWrap: 1) equals: 1.
+	
+	self assert: (array atColumnWrap: 2 atRowWrap: 4) equals: 2.
+	
+	self assert: (array atColumnWrap: 0 atRowWrap: 0) equals: 6.
+]
+
+{ #category : 'tests-accessing' }
+CTArray2DTest >> testAtColumnWrapAtRowWrapPut [
+
+	| array |
+	array := self arrayClass width2Height3.
+	
+	array atColumnWrap: 3 atRowWrap: 2 put: 99.
+	self assert: (array atColumn: 1 atRow: 2) equals: 99.
+	
+	array atColumnWrap: 0 atRowWrap: 0 put: 88.
+	self assert: (array atColumn: 2 atRow: 3) equals: 88.
+]
+
+{ #category : 'tests-accessing' }
 CTArray2DTest >> testAtPut [
 	
 	| foo |
@@ -234,6 +262,33 @@ CTArray2DTest >> testLeftToRightFromBottomToTopDo [
 	a2d leftToRightFromBottomToTopDo: [ :each | res add: each ].
 	self assert: res equals: #(4 5 6 1 2 3 ) asOrderedCollection
 	 
+]
+
+{ #category : 'tests-accessing' }
+CTArray2DTest >> testNeighborsAtColumnAtRow [
+
+	| array neighbors topCornerNeighbors |
+	array := self arrayClass width2Height3.
+	
+	neighbors := array neighborsAtColumn: 1 atRow: 2.
+	self assert: neighbors size equals: 5.
+	self assert: (neighbors includesAll: #(1 2 4 5 6)).
+	
+	topCornerNeighbors := array neighborsAtColumn: 1 atRow: 1.
+	self assert: topCornerNeighbors size equals: 3.
+	self assert: (topCornerNeighbors includesAll: #(2 3 4)).
+]
+
+{ #category : 'tests-accessing' }
+CTArray2DTest >> testNeighborsEight [
+
+	| array neighbors |
+	array := self arrayClass fromArray: #(1 2 3 4 5 6 7 8 9) width: 3.
+	
+	neighbors := array neighborsAtColumn: 2 atRow: 2.
+	
+	self assert: neighbors size equals: 8.
+	self assert: (neighbors includesAll: #(1 2 3 4 6 7 8 9)).
 ]
 
 { #category : 'tests-printing' }

--- a/src/Containers-Array2D-Tests/CTArray2DTest.class.st
+++ b/src/Containers-Array2D-Tests/CTArray2DTest.class.st
@@ -279,6 +279,38 @@ CTArray2DTest >> testNeighborsAtColumnAtRow [
 	self assert: (topCornerNeighbors includesAll: #(2 3 4)).
 ]
 
+{ #category : 'tests' }
+CTArray2DTest >> testNeighborsAtColumnAtRowOutOfBounds [
+
+	| array |
+
+	array := self arrayClass width2Height3.
+
+	self should: [ array neighborsAtColumn: 99 atRow: 99 ] raise: Error.
+]
+
+{ #category : 'tests' }
+CTArray2DTest >> testNeighborsAtColumnWrapAtRowWrap [
+
+	| array neighbors |
+
+	array := self arrayClass fromArray: #(1 2 3 4 5 6 7 8 9) width: 3.
+
+	neighbors := array neighborsAtColumnWrap: 1 atRowWrap: 1.
+
+	self assert: neighbors size equals: 8.
+	self assert: (neighbors includesAll: #(2 3 4 5 6 7 8 9)).
+]
+
+{ #category : 'tests' }
+CTArray2DTest >> testNeighborsAtColumnWrapAtRowWrapOutOfBounds [
+	| array |
+
+	array := self arrayClass width2Height3.
+
+	self should: [ array neighborsAtColumnWrap: 99 atRowWrap: 99 ] raise: Error.
+]
+
 { #category : 'tests-accessing' }
 CTArray2DTest >> testNeighborsEight [
 

--- a/src/Containers-Array2D/CTArray2D.class.st
+++ b/src/Containers-Array2D/CTArray2D.class.st
@@ -195,6 +195,7 @@ CTArray2D >> atColumn: x put: aCollection [
 
 { #category : 'accessing' }
 CTArray2D >> atColumnWrap: col atRowWrap: row [
+	"Answer the element at the given coordinates. If the coordinates are outside the grid bounds, they wrap around using 1-based indexing logic to ensure seamless boundary traversal."
 	
 	| wrappedCol wrappedRow |
 	wrappedCol := ((col - 1) \\ self width) + 1.
@@ -205,7 +206,8 @@ CTArray2D >> atColumnWrap: col atRowWrap: row [
 
 { #category : 'accessing' }
 CTArray2D >> atColumnWrap: col atRowWrap: row put: aValue [
-
+	"Store the given value at the specified coordinates. If the coordinates are  outside the grid bounds, they wrap around using 1-based indexing logic (e.g., in a grid of width 3, column 4 wraps to 1, and column 0 wraps to 3)."
+	
 	| wrappedCol wrappedRow |
 	wrappedCol := ((col - 1) \\ self width) + 1.
 	wrappedRow := ((row - 1) \\ self height) + 1.
@@ -375,7 +377,8 @@ CTArray2D >> isSelfEvaluating [
 
 { #category : 'enumerating' }
 CTArray2D >> neighborsAtColumn: col atRow: row [
-
+	"Answer a collection of up to 8 valid elements surrounding the given origin. This method does not wrap; neighbors that would fall outside the grid are ignored. Throws an error if the starting origin coordinates are out of bounds."
+	
 	| neighbors |
 
 	(col between: 1 and: self width) ifFalse: [ self error: 'Column out of bounds' ].
@@ -395,7 +398,8 @@ CTArray2D >> neighborsAtColumn: col atRow: row [
 
 { #category : 'enumerating' }
 CTArray2D >> neighborsAtColumnWrap: col atRowWrap: row [
-
+	"Answer a collection of exactly 8 elements surrounding the given origin, wrapping across grid boundaries where necessary. Throws an error if the starting origin coordinates are out of bounds."
+	
 	| neighbors |
 
 	(col between: 1 and: self width) ifFalse: [ self error: 'Column out of bounds' ].

--- a/src/Containers-Array2D/CTArray2D.class.st
+++ b/src/Containers-Array2D/CTArray2D.class.st
@@ -323,17 +323,39 @@ CTArray2D >> leftToRightFromBottomToTopDo: aBlock [
 
 { #category : 'enumerating' }
 CTArray2D >> neighborsAtColumn: col atRow: row [
-	
+
 	| neighbors |
+
+	(col between: 1 and: self width) ifFalse: [ self error: 'Column out of bounds' ].
+	(row between: 1 and: self height) ifFalse: [ self error: 'Row out of bounds' ].
+
 	neighbors := OrderedCollection new.
-	
+
 	row - 1 to: row + 1 do: [ :r |
 		col - 1 to: col + 1 do: [ :c |
 			(r = row and: [ c = col ]) ifFalse: [
 				(r between: 1 and: self height) ifTrue: [
 					(c between: 1 and: self width) ifTrue: [
 						neighbors add: (self atColumn: c atRow: r) ] ] ] ] ].
-						
+
+	^ neighbors
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> neighborsAtColumnWrap: col atRowWrap: row [
+
+	| neighbors |
+
+	(col between: 1 and: self width) ifFalse: [ self error: 'Column out of bounds' ].
+	(row between: 1 and: self height) ifFalse: [ self error: 'Row out of bounds' ].
+
+	neighbors := OrderedCollection new.
+
+	row - 1 to: row + 1 do: [ :r |
+		col - 1 to: col + 1 do: [ :c |
+			(r = row and: [ c = col ]) ifFalse: [
+				neighbors add: (self atColumnWrap: c atRowWrap: r) ] ] ].
+
 	^ neighbors
 ]
 

--- a/src/Containers-Array2D/CTArray2D.class.st
+++ b/src/Containers-Array2D/CTArray2D.class.st
@@ -193,6 +193,26 @@ CTArray2D >> atColumn: x put: aCollection [
 	^ aCollection
 ]
 
+{ #category : 'accessing' }
+CTArray2D >> atColumnWrap: col atRowWrap: row [
+	
+	| wrappedCol wrappedRow |
+	wrappedCol := ((col - 1) \\ self width) + 1.
+	wrappedRow := ((row - 1) \\ self height) + 1.
+	
+	^ self atColumn: wrappedCol atRow: wrappedRow
+]
+
+{ #category : 'accessing' }
+CTArray2D >> atColumnWrap: col atRowWrap: row put: aValue [
+
+	| wrappedCol wrappedRow |
+	wrappedCol := ((col - 1) \\ self width) + 1.
+	wrappedRow := ((row - 1) \\ self height) + 1.
+	
+	^ self atColumn: wrappedCol atRow: wrappedRow put: aValue
+]
+
 { #category : 'accessing rows/columns' }
 CTArray2D >> atRow: y [
 	"Answer the content of the whole column at y"
@@ -299,6 +319,22 @@ CTArray2D >> leftToRightFromBottomToTopDo: aBlock [
 	 self height to: 1 by: -1 do: [:row |
 		1 to: self width do: [:col |
 			aBlock  value: (self atColumn: col atRow: row)]]
+]
+
+{ #category : 'enumerating' }
+CTArray2D >> neighborsAtColumn: col atRow: row [
+	
+	| neighbors |
+	neighbors := OrderedCollection new.
+	
+	row - 1 to: row + 1 do: [ :r |
+		col - 1 to: col + 1 do: [ :c |
+			(r = row and: [ c = col ]) ifFalse: [
+				(r between: 1 and: self height) ifTrue: [
+					(c between: 1 and: self width) ifTrue: [
+						neighbors add: (self atColumn: c atRow: r) ] ] ] ] ].
+						
+	^ neighbors
 ]
 
 { #category : 'accessing - compatibility' }


### PR DESCRIPTION
This PR implements the boundary and adjacency logic.
- **Wrapping:** Added `atColumnWrap:atRowWrap:` and `atColumnWrap:atRowWrap:put:` to allow seamless boundary wrapping using 1-based modulo arithmetic.
- **Neighbors:** Added `neighborsAtColumn:atRow:` to safely fetch up to 8 surrounding valid elements without out-of-bounds errors.
- **Testing:** Added tests in `CTArray2DTest` covering normal access, edge wrapping and a full 8-neighbor.

- **Fixes #17**